### PR TITLE
Fix typo(babecue->barbecue)

### DIFF
--- a/LISENCE.txt
+++ b/LISENCE.txt
@@ -1,3 +1,3 @@
-This recipe is lisenced by Babecue Source Distribution.
+This recipe is lisenced by Barbecue Source Distribution.
 Permission to dip, cook, arrange and/or distribute this source  for any purpose with or without fee is hereby granted.
 Enjoy BBQ.

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@
 レシピは recipe.md に記してあります。
 
 ## Lisence
-このソースはBabecue Source Distributionによって保護されています。
+このソースはBarbecue Source Distributionによって保護されています。
 詳しくは Lisence.txt をご覧ください。


### PR DESCRIPTION
おそらく表記ミスかと思いますが、何かの洒落を踏まえて付けられていたのでしたらごめんなさい。